### PR TITLE
feat: migrate config path to XDG-compliant location

### DIFF
--- a/docs/adr/0005-xdg-config-path.md
+++ b/docs/adr/0005-xdg-config-path.md
@@ -1,0 +1,50 @@
+# ADR 0005: XDG-Compliant Config Path via platformdirs
+
+**Status: Accepted**   
+**Date: 24-04-2026**   
+
+## Context
+v0.1.0 stores config at `~/.scaffoldr/config.toml` and user issue
+templates at `~/.scaffoldr/issues.toml`.
+The `~/.scaffoldr/` convention clutters the home directory and 
+ignores the XDG Base Directory Specification, which defines 
+`$XDG_CONFIG_HOME` (defaulting to `~/.config/`) as the correct 
+location for user config files on linux.
+macOS and Windows have their own conventions.
+
+Hardcoding `~/.scaffoldr/` also means that `scaffoldr` behaves
+differently from the rest of the CLI tool ecosystem..
+
+## Decision
+Use the `platformdirs` library to resolve the config directory at 
+runtime via `user_config_dir("scaffoldr")`.
+This yields:
+  Linux:   `~/.config/scaffoldr/`       (or `$XDG_CONFIG_HOME`)
+  macOS:   `~/Library/Application Support/scaffoldr/`
+  Windows: `C:\Users\<user>\AppData\Local\scaffoldr`
+
+All config-path references in the codebase will use a single
+`CONFIG_DIR` constant derived from `platformdirs`. 
+The old `~/.scaffoldr/` path will be detected on startup; if 
+present and the new path is absent, a deprecation warning is 
+printed to stderr. A `scaffoldr config migrate` command will move 
+files to the new location.
+
+## Alternatives Considered
+- Hardcode `~/.config/scaffoldr/`: correct on Linux but wrong on 
+  macOS and windows. Rejected.
+- Use the `appdirs` library: predecessor to `platformdirs`, 
+  unmaintained since 2021. Rejected.
+- Keep `~/.scaffoldr`: non-standard, clutters home dir, 
+  inconsistent with ecosystem. Rejected
+
+## Consequences
+### Positives
+- Follows platform conventions on all OSes
+- Single config directory footprint for all future scaffoldr
+  config files (templates dir, etc.)
+
+### Negatives
+- Breaking changes for v0.1.0 users - mitigated by automatic
+  detection and migrate command
+- New dependency: `platformdirs>=4.0.0`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,8 @@ scaffoldr = "scaffoldr.main:app"
 [project.optional-dependencies]
 dev = [
     "pytest>=8.0.0",
-    "ruff>=0.4.0"
+    "ruff>=0.4.0",
+    "platformdirs>=4.0.0"
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,8 @@ dev = [
 ]
 
 [tool.ruff]
-line-length = 72
-target-version = "py310"
+line-length = 64
+target-version = "py311"
 
 [tool.ruff.lint]
 select = ["E", "F", "I"]

--- a/scaffoldr/config.py
+++ b/scaffoldr/config.py
@@ -44,7 +44,9 @@ class Config:
             ),
             default_private=data.get("default_private", False),
             github_token=data.get("github_token", ""),
-            required_reviewers=data.get("required_reviewers", 1),
+            required_reviewers=data.get(
+                "required_reviewers", 1
+            ),
             use_ssh=data.get("use_ssh", True),
             extra={
                 k: v
@@ -70,6 +72,7 @@ class Config:
             f'github_username = "{self.github_username}"\n',
             f'license = "{self.license}"\n',
             f'python_version = "{self.python_version}"\n',
+            # ruff: noqa: E501
             f"default_private = {str(self.default_private).lower()}\n",
             f'github_token = "{self.github_token}"\n',
             f"required_reviewers = {self.required_reviewers}\n",

--- a/scaffoldr/config.py
+++ b/scaffoldr/config.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from platformdirs import user_config_dir
+
 try:
     import tomllib
 except ImportError:
     import tomli as tomllib
 
-CONFIG_DIR = Path.home() / ".scaffoldr"
+CONFIG_DIR = Path(user_config_dir("scaffoldr"))
 CONFIG_FILE = CONFIG_DIR / "config.toml"
 
 DEFAULT_PYTHON_VERSION = "3.10"

--- a/scaffoldr/github.py
+++ b/scaffoldr/github.py
@@ -66,14 +66,16 @@ def create_repo(
 
         if response.status_code == 422:
             typer.echo(
-                f"Error: repo '{name}' already exists on GitHub.",
+                f"Error: repo '{name}' already exists"
+                " on GitHub.",
                 err=True,
             )
             raise typer.Exit(code=1)
 
         if response.status_code == 401:
             typer.echo(
-                "Error: invald or expired GitHub token.", err=True
+                "Error: invald or expired GitHub token.",
+                err=True,
             )
             raise typer.Exit(code=1)
 
@@ -94,7 +96,8 @@ def get_authenticated_user(client: httpx.Client) -> str:
     response = client.get("/user")
     if not response.is_success:
         typer.echo(
-            "Error: could not fetch GitHub user - check you token.",
+            "Error: could not fetch GitHub user - check"
+            " you token.",
             err=True,
         )
         raise typer.Exit(code=1)

--- a/scaffoldr/issues.py
+++ b/scaffoldr/issues.py
@@ -67,7 +67,9 @@ def resolve_templates() -> list[dict]:
     user_issues = _load_user_issues()
     user_titles = {i["title"] for i in user_issues}
     merged = [
-        i for i in DEFAULT_ISSUES if i["title"] not in user_titles
+        i
+        for i in DEFAULT_ISSUES
+        if i["title"] not in user_titles
     ]
     merged.extend(user_issues)
     return merged
@@ -98,7 +100,9 @@ def create_issues(owner: str, repo: str, client) -> list[dict]:
             raise typer.Exit(code=1)
 
         if response.status_code == 403:
-            typer.echo("Error: rate limited by GitHub API.", err=True)
+            typer.echo(
+                "Error: rate limited by GitHub API.", err=True
+            )
             raise typer.Exit(code=1)
 
         if not response.is_success:
@@ -112,6 +116,8 @@ def create_issues(owner: str, repo: str, client) -> list[dict]:
 
         issue = response.json()
         created.append(issue)
-        typer.echo(f"Created: #{issue['number']} {issue['title']}")
+        typer.echo(
+            f"Created: #{issue['number']} {issue['title']}"
+        )
 
     return created

--- a/scaffoldr/local.py
+++ b/scaffoldr/local.py
@@ -24,7 +24,9 @@ def _git(args: list[str], cwd: Path) -> None:
         text=True,
     )
     if result.returncode != 0:
-        typer.echo(f"git error: {result.stderr.strip()}", err=True)
+        typer.echo(
+            f"git error: {result.stderr.strip()}", err=True
+        )
         raise typer.Exit(code=1)
 
 
@@ -49,16 +51,23 @@ def scaffold(project_name: str, path: Path) -> None:
     (root / ".github" / "workflows").mkdir(parents=True)
 
     # files
-    (root / "README.md").write_text(readme(project_name, cfg.author))
-    (root / "CONTRIBUTING.md").write_text(contributing(project_name))
+    (root / "README.md").write_text(
+        readme(project_name, cfg.author)
+    )
+    (root / "CONTRIBUTING.md").write_text(
+        contributing(project_name)
+    )
     (root / "pyproject.toml").write_text(
         pyproject(
-            project_name, cfg.author, cfg.python_version, cfg.license
+            project_name,
+            cfg.author,
+            cfg.python_version,
+            cfg.license,
         )
     )
-    (root / "docs" / "adr" / "0001-initial-decisions.md").write_text(
-        adr_template(project_name)
-    )
+    (
+        root / "docs" / "adr" / "0001-initial-decisions.md"
+    ).write_text(adr_template(project_name))
     (root / ".gitignore").write_text(gitignore())
     (root / "tests" / "__init__.py").write_text("")
     (root / project_name / "__init__.py").write_text("")

--- a/scaffoldr/main.py
+++ b/scaffoldr/main.py
@@ -102,7 +102,7 @@ def config_init(
         True, prompt="Use SSH for git remote?"
     ),
 ) -> None:
-    """Create ~/.scaffoldr/config.toml interactively."""
+    """Create ~/.config/scaffoldr/config.toml interactively."""
     if CONFIG_FILE.exists():
         overwrite = typer.confirm(
             f"{CONFIG_FILE} already exists. Overwrite?"

--- a/scaffoldr/main.py
+++ b/scaffoldr/main.py
@@ -7,6 +7,7 @@ from typing import Optional
 import typer
 
 from scaffoldr.config import (
+    CONFIG_DIR,
     CONFIG_FILE,
     DEFAULT_LICENSE,
     DEFAULT_PYTHON_VERSION,
@@ -30,11 +31,40 @@ app = typer.Typer(
     no_args_is_help=True,
 )
 
+
+def check_legacy_config():
+    legacy_path = Path.home() / ".scaffoldr"
+    if legacy_path.exists():
+        typer.echo(
+            f"Config directory changed from {legacy_path} to"
+            f" {CONFIG_DIR}."
+            "\nRun `scaffoldr config migrate` to move existing"
+            " config.",
+            err=True,
+        )
+        raise typer.Abort()
+
+
 config_app = typer.Typer(name="config", help="Manage scaffoldr config.")
 app.add_typer(config_app)
 
+
 issues_app = typer.Typer(name="issues", help="Manage GitHub issues.")
 app.add_typer(issues_app)
+
+
+@app.callback()
+def app_callback(ctx: typer.Context):
+    if ctx.invoked_subcommand == "config":
+        return
+    check_legacy_config()
+
+
+@config_app.callback()
+def config_callback(ctx: typer.Context):
+    if ctx.invoked_subcommand == "migrate":
+        return
+    check_legacy_config()
 
 
 @config_app.command("init")

--- a/scaffoldr/main.py
+++ b/scaffoldr/main.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
+from shutil import copy2 as shutil_copy2
+from shutil import rmtree as shutil_rmtree
 from typing import Optional
 
 import typer
@@ -23,7 +25,9 @@ from scaffoldr.github import (
 )
 from scaffoldr.issues import create_issues as _create_issues
 from scaffoldr.local import scaffold as _scaffold
-from scaffoldr.protection import protect_branch as _protect_branch
+from scaffoldr.protection import (
+    protect_branch as _protect_branch,
+)
 
 app = typer.Typer(
     name="scaffoldr",
@@ -45,11 +49,15 @@ def check_legacy_config():
         raise typer.Abort()
 
 
-config_app = typer.Typer(name="config", help="Manage scaffoldr config.")
+config_app = typer.Typer(
+    name="config", help="Manage scaffoldr config."
+)
 app.add_typer(config_app)
 
 
-issues_app = typer.Typer(name="issues", help="Manage GitHub issues.")
+issues_app = typer.Typer(
+    name="issues", help="Manage GitHub issues."
+)
 app.add_typer(issues_app)
 
 
@@ -69,11 +77,15 @@ def config_callback(ctx: typer.Context):
 
 @config_app.command("init")
 def config_init(
-    author: Optional[str] = typer.Option(None, prompt="Author name"),
+    author: Optional[str] = typer.Option(
+        None, prompt="Author name"
+    ),
     github_username: Optional[str] = typer.Option(
         None, prompt="GitHub username"
     ),
-    license: str = typer.Option(DEFAULT_LICENSE, prompt="License"),
+    license: str = typer.Option(
+        DEFAULT_LICENSE, prompt="License"
+    ),
     python_version: str = typer.Option(
         DEFAULT_PYTHON_VERSION, prompt="Python version"
     ),
@@ -131,6 +143,53 @@ def config_show() -> None:
     typer.echo(f"github_token       = {masked}")
 
 
+@config_app.command()
+def migrate() -> None:
+    legacy_path = Path.home() / ".scaffoldr"
+    if not legacy_path.exists():
+        typer.echo("Legacy config does not exist.")
+        return
+
+    if CONFIG_DIR.exists():
+        overwrite = typer.confirm(
+            f"{CONFIG_DIR} already exists. Overwrite?"
+        )
+        if not overwrite:
+            raise typer.Abort()
+
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+
+    for item in legacy_path.rglob("*"):
+        relative_path = item.relative_to(legacy_path)
+        destination_item = CONFIG_DIR / relative_path
+
+        if item.is_file():
+            destination_item.parent.mkdir(
+                parents=True, exist_ok=True
+            )
+            shutil_copy2(item, destination_item)
+        else:
+            destination_item.mkdir(parents=True, exist_ok=True)
+
+    try:
+        shutil_rmtree(legacy_path)
+        typer.echo(f"Successfully removed {legacy_path}")
+    except PermissionError:
+        typer.echo(
+            f"Permission denied when removing {legacy_path}",
+            err=True,
+        )
+        raise typer.Abort()
+    except Exception as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Abort()
+
+    typer.echo(
+        "Config files migrated successfully from "
+        f"{legacy_path} to {CONFIG_DIR}"
+    )
+
+
 @issues_app.command("create")
 def issues_create(
     repo: str = typer.Argument(
@@ -168,7 +227,9 @@ def new(
     project_name: str = typer.Argument(
         ..., help="Name of the new project"
     ),
-    description: str = typer.Option("", help="GitHub repo description"),
+    description: str = typer.Option(
+        "", help="GitHub repo description"
+    ),
     private: Optional[bool] = typer.Option(
         None, help="Override default_private from config"
     ),
@@ -184,13 +245,17 @@ def new(
     GitHub repo for it.
     """
     cfg = Config.load()
-    is_private = private if private is not None else cfg.default_private
+    is_private = (
+        private if private is not None else cfg.default_private
+    )
 
     _scaffold(project_name, path)
 
     typer.echo("Creating GitHub repo...")
     repo = _create_repo(
-        name=project_name, description=description, private=is_private
+        name=project_name,
+        description=description,
+        private=is_private,
     )
 
     root = path / project_name
@@ -202,7 +267,8 @@ def new(
     else:
         token = _get_token()
         remote_url = clone_url.replace(
-            "https://", f"https://{cfg.github_username}:{token}@"
+            "https://",
+            f"https://{cfg.github_username}:{token}@",
         )
 
     subprocess.run(
@@ -211,7 +277,9 @@ def new(
         check=True,
     )
     subprocess.run(
-        ["git", "push", "-u", "origin", "main"], cwd=root, check=True
+        ["git", "push", "-u", "origin", "main"],
+        cwd=root,
+        check=True,
     )
 
     if not cfg.use_ssh:

--- a/scaffoldr/protection.py
+++ b/scaffoldr/protection.py
@@ -24,7 +24,9 @@ def protect_branch(
             },
             "enforce_admins": False,
             "required_pull_request_reviews": {
-                "required_approving_review_count": (required_reviewers),
+                "required_approving_review_count": (
+                    required_reviewers
+                ),
                 "dismiss_stale_reviews": False,
                 "required_code_owner_reviews": False,
             },

--- a/scaffoldr/templates.py
+++ b/scaffoldr/templates.py
@@ -64,7 +64,10 @@ pytest
 
 
 def pyproject(
-    project_name: str, author: str, python_version: str, license_: str
+    project_name: str,
+    author: str,
+    python_version: str,
+    license_: str,
 ) -> str:
     return f"""\
 [build-system]
@@ -133,7 +136,10 @@ build/
 """
 
 
-def github_actions_ci(project_name: str, python_version: str) -> str:
+def github_actions_ci(
+    project_name: str, python_version: str
+) -> str:
+    # ruff: noqa: E501
     return f"""\
 name: CI
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -16,14 +16,19 @@ def test_create_repo_success():
     }
 
     with (
-        patch("scaffoldr.github._get_token", return_value="fake-token"),
+        patch(
+            "scaffoldr.github._get_token",
+            return_value="fake-token",
+        ),
         patch("httpx.Client.post", return_value=mock_response),
     ):
         from scaffoldr.github import create_repo
 
         result = create_repo("myrepo")
 
-    assert result["html_url"] == ("https://github.com/user/myrepo")
+    assert result["html_url"] == (
+        "https://github.com/user/myrepo"
+    )
 
 
 def test_create_repo_already_exists():
@@ -32,7 +37,10 @@ def test_create_repo_already_exists():
     mock_response.is_success = False
 
     with (
-        patch("scaffoldr.github._get_token", return_value="fake-token"),
+        patch(
+            "scaffoldr.github._get_token",
+            return_value="fake-token",
+        ),
         patch("httpx.Client.post", return_value=mock_response),
     ):
         from scaffoldr.github import create_repo
@@ -47,7 +55,10 @@ def test_create_repo_invalid_token():
     mock_response.is_succes = False
 
     with (
-        patch("scaffoldr.github._get_token", return_vlaue="fake-token"),
+        patch(
+            "scaffoldr.github._get_token",
+            return_vlaue="fake-token",
+        ),
         patch("httpx.Client.post", return_value=mock_response),
     ):
         from scaffoldr.github import create_repo

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -13,7 +13,9 @@ from scaffoldr.issues import (
 
 
 def test_resolve_templates_returns_defaults():
-    with patch("scaffoldr.issues._load_user_issues", return_value=[]):
+    with patch(
+        "scaffoldr.issues._load_user_issues", return_value=[]
+    ):
         templates = resolve_templates()
     assert templates == DEFAULT_ISSUES
 
@@ -24,7 +26,8 @@ def test_user_templates_override_defaults():
         "body": "custom body",
     }
     with patch(
-        "scaffoldr.issues._load_user_issues", return_value=[user_issue]
+        "scaffoldr.issues._load_user_issues",
+        return_value=[user_issue],
     ):
         templates = resolve_templates()
 
@@ -44,7 +47,8 @@ def test_user_templates_extend_defaults():
         "body": "custom body",
     }
     with patch(
-        "scaffoldr.issues._load_user_issues", return_value=[user_issue]
+        "scaffoldr.issues._load_user_issues",
+        return_value=[user_issue],
     ):
         templates = resolve_templates()
 
@@ -66,7 +70,9 @@ def test_create_issues_success():
     }
     mock_client.post.return_value = mock_response
 
-    with patch("scaffoldr.issues._load_user_issues", return_value=[]):
+    with patch(
+        "scaffoldr.issues._load_user_issues", return_value=[]
+    ):
         created = create_issues("user", "repo", mock_client)
 
     assert len(created) == len(DEFAULT_ISSUES)
@@ -79,6 +85,8 @@ def test_create_issues_rate_limited():
     mock_response.is_success = False
     mock_client.post.return_value = mock_response
 
-    with patch("scaffoldr.issues._load_user_issues", return_value=[]):
+    with patch(
+        "scaffoldr.issues._load_user_issues", return_value=[]
+    ):
         with pytest.raises(click.exceptions.Exit):
             create_issues("user", "repo", mock_client)

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -67,14 +67,20 @@ def test_already_exists_raises(tmp_path):
 
 
 def test_ci_workflow_created(project):
-    assert (project / ".github" / "workflows" / "ci.yml").exists()
+    assert (
+        project / ".github" / "workflows" / "ci.yml"
+    ).exists()
 
 
 def test_ci_workflow_contains_python_version(project):
-    content = (project / ".github" / "workflows" / "ci.yml").read_text()
+    content = (
+        project / ".github" / "workflows" / "ci.yml"
+    ).read_text()
     assert DUMMY_CONFIG.python_version in content
 
 
 def test_ci_workflow_contains_explicit_installs(project):
-    content = (project / ".github" / "workflows" / "ci.yml").read_text()
+    content = (
+        project / ".github" / "workflows" / "ci.yml"
+    ).read_text()
     assert "pip install ruff pytest" in content


### PR DESCRIPTION
## What
Migrated config from ~/.scaffoldr/config.toml to
~/.config/scaffoldr/config.toml using platformdirs
for cross-platform correctness.

## Changes
- `pyproject.toml`: platformdirs added to dependencies and 
  line-width changed to 64chars
- `docs/adr/0005-xdg-config-path.md`: added ADR for XDG config
  path migration
- `config.py`: CONFIG_DIR now points to user_config_dir("scaffoldr")
- `main.py`: added check_legacy_config for callbacks and migrate
  command

## Why
Migrating config files to XDG-compliant config path prevents
clutter in the home directory and brings `scaffoldr` in line
with the rest of the toolchain.

## Impact
This is a breaking change -> v0.2.0.

## Checklist
- [x] Closes #31 
- [x] $XDG_CONFIG_HOME is respected on Linux
- [x] All config path references use user_config_dir
- [x] Old config path (~/.scaffoldr/config.toml), prompts 
      `scaffoldr config migrate` and aborts
- [x] scaffoldr config migrate command moves contents of 
      old config dir to new location
