### PR TITLE
feat: scaffoldr template list command

### DIFF
--- a/scaffoldr/main.py
+++ b/scaffoldr/main.py
@@ -6,6 +6,7 @@ from scaffoldr.config import app as config_app
 from scaffoldr.init import app as init_app
 from scaffoldr.issues import app as issues_app
 from scaffoldr.new import app as new_app
+from scaffoldr.template import app as template_app
 from scaffoldr.utils import check_legacy_config, ensure_dirs
 
 app = typer.Typer(
@@ -18,6 +19,7 @@ app.add_typer(init_app)
 app.add_typer(new_app)
 app.add_typer(config_app, name="config")
 app.add_typer(issues_app, name="issues")
+app.add_typer(template_app, name="template")
 
 
 @app.callback()

--- a/scaffoldr/template/__init__.py
+++ b/scaffoldr/template/__init__.py
@@ -1,0 +1,6 @@
+from typer import Typer
+
+from .list import app as list_app
+
+app = Typer(help="Manage scaffoldr templates.")
+app.add_typer(list_app)

--- a/scaffoldr/template/list.py
+++ b/scaffoldr/template/list.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+from typer import Typer
+from typer import echo as typer_echo
+
+from scaffoldr.template_handler import (
+    BUILTIN_TEMPLATES_PATH,
+    get_description,
+)
+from scaffoldr.user_config import USER_DEFINED_TEMPLATES_PATH
+
+app = Typer()
+
+
+@app.command("list")
+def list_cmd():
+    typer_echo("Built-in:")
+    found = False
+    for t in list_templates(BUILTIN_TEMPLATES_PATH):
+        found = True
+        typer_echo(t)
+
+    if found:
+        typer_echo("\n")
+    else:
+        typer_echo("(none)\n")
+
+    typer_echo(f"User ({USER_DEFINED_TEMPLATES_PATH})")
+    found = False
+    for t in list_templates(USER_DEFINED_TEMPLATES_PATH):
+        found = True
+        typer_echo(t)
+
+    if not found:
+        typer_echo("(none)")
+
+
+def list_templates(dir_path: Path) -> list[str]:
+    template_list = []
+    for path in dir_path.iterdir():
+        if path.is_file():
+            template_list.append(
+                f"{path.stem}   {get_description(path)}"
+            )
+
+    return template_list

--- a/scaffoldr/template_handler.py
+++ b/scaffoldr/template_handler.py
@@ -88,3 +88,31 @@ def render_template(
         ) from e
 
     return result
+
+
+def get_description(path: Path) -> str:
+    try:
+        with path.open("rb") as f:
+            data: dict[str, Any] = toml_load(f)
+            return data["description"]
+    except FileNotFoundError:
+        raise TemplateError(
+            f"Template file not found: {path.stem}"
+        )
+    except PermissionError:
+        raise TemplateError(
+            f"Permission denied reading template: {path.stem}"
+        )
+    except TOMLDecodeError as e:
+        raise TemplateError(
+            f"Invalid TOML in template file {path.stem}: {e}"
+        ) from e
+    except OSError as e:
+        raise TemplateError(
+            f"Failed to read template file {path.stem}: {e}"
+        ) from e
+    except KeyError:
+        raise TemplateError(
+            "Missing 'description' in template file "
+            f"{path.stem}"
+        )


### PR DESCRIPTION
## What
Added `scaffoldr template list` to show available built-in
and user-defined templates.

## Changes
- `scaffoldr/template_handler.py`: added helper to get template 
  description
- `scaffoldr/template/list.py`: added template list command
- `scaffoldr/main.py`: registered `template_app` in `main.py`
- `scaffoldr/template/__init__.py`: created template app and
  registered list command

## Why
Lists available project templates for scaffolding project
improving UX.

## Impact
Non-breaking. Adds new `scaffoldr template list` subcommand.

## Checklist
- [x] Closes #33 
- [x] All tests pass
- [x] CI green