### PR TITLE
refactor: replace typer.Exit in business logic with custom exceptions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ scaffoldr = "scaffoldr.main:app"
 dev = [
     "pytest>=8.0.0",
     "ruff>=0.4.0",
-    "click>=8.4.1",
 ]
 
 [tool.ruff]

--- a/scaffoldr/exceptions.py
+++ b/scaffoldr/exceptions.py
@@ -1,2 +1,14 @@
 class TemplateError(Exception):
     """Raised when a template operation fails."""
+
+
+class GitHubError(Exception):
+    """Raised when a GitHub operation fails."""
+
+
+class LocalError(Exception):
+    """Raised when a local scaffold operation fails."""
+
+
+class GitError(Exception):
+    """Raised when a git operation fails."""

--- a/scaffoldr/github.py
+++ b/scaffoldr/github.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import os
 
 import httpx
-import typer
 
+from scaffoldr.exceptions import GitHubError
 from scaffoldr.user_config import Config
 
 GITHUB_API = "https://api.github.com"
@@ -17,13 +17,12 @@ def _get_token() -> str:
     cfg = Config.load()
     if cfg.github_token:
         return cfg.github_token
-    typer.echo(
+
+    raise GitHubError(
         "Error no GitHub token found.\n"
         "Set SCAFFOLDR_GITHUB_TOKEN env var or run "
         "`scaffoldr config init` to save a token.",
-        err=True,
     )
-    raise typer.Exit(code=1)
 
 
 def _client() -> httpx.Client:
@@ -65,28 +64,22 @@ def create_repo(
         )
 
         if response.status_code == 422:
-            typer.echo(
+            raise GitHubError(
                 f"Error: repo '{name}' already exists"
                 " on GitHub.",
-                err=True,
             )
-            raise typer.Exit(code=1)
 
         if response.status_code == 401:
-            typer.echo(
+            raise GitHubError(
                 "Error: invald or expired GitHub token.",
-                err=True,
             )
-            raise typer.Exit(code=1)
 
         if not response.is_success:
-            typer.echo(
+            raise GitHubError(
                 f"Error: GitHub API returned "
                 f"{response.status_code} - "
                 f"{response.text}",
-                err=True,
             )
-            raise typer.Exit(code=1)
 
         return response.json()
 
@@ -95,10 +88,8 @@ def get_authenticated_user(client: httpx.Client) -> str:
     """Return the authenticated GitHub username."""
     response = client.get("/user")
     if not response.is_success:
-        typer.echo(
+        raise GitHubError(
             "Error: could not fetch GitHub user - check"
             " you token.",
-            err=True,
         )
-        raise typer.Exit(code=1)
     return response.json()["login"]

--- a/scaffoldr/init.py
+++ b/scaffoldr/init.py
@@ -6,7 +6,11 @@ from typer import Option as typer_option
 from typer import Typer
 from typer import echo as typer_echo
 
-from scaffoldr.exceptions import TemplateError
+from scaffoldr.exceptions import (
+    GitError,
+    LocalError,
+    TemplateError,
+)
 from scaffoldr.local import scaffold as _scaffold
 
 app = Typer(help="Scaffold a new project locally.")
@@ -27,6 +31,6 @@ def init(
     """Scaffold a new project locally."""
     try:
         _scaffold(project_name, template, path)
-    except TemplateError as e:
+    except (TemplateError, LocalError, GitError) as e:
         typer_echo(e, err=True)
         raise typer_exit(code=1)

--- a/scaffoldr/issue_handler.py
+++ b/scaffoldr/issue_handler.py
@@ -5,8 +5,9 @@ try:
 except ImportError:
     import tomli as tomllib
 
-import typer
+from typer import echo as typer_echo
 
+from scaffoldr.exceptions import GitHubError
 from scaffoldr.user_config import CONFIG_DIR
 
 ISSUES_FILE = CONFIG_DIR / "issues.toml"
@@ -93,30 +94,25 @@ def create_issues(owner: str, repo: str, client) -> list[dict]:
         )
 
         if response.status_code == 410:
-            typer.echo(
+            raise GitHubError(
                 "Error: issues are disabled on this repo.",
-                err=True,
             )
-            raise typer.Exit(code=1)
 
         if response.status_code == 403:
-            typer.echo(
-                "Error: rate limited by GitHub API.", err=True
+            raise GitHubError(
+                "Error: rate limited by GitHub API.",
             )
-            raise typer.Exit(code=1)
 
         if not response.is_success:
-            typer.echo(
+            raise GitHubError(
                 f"Error: failed to create issue "
                 f"'{template['title']}' - "
                 f"{response.status_code}",
-                err=True,
             )
-            raise typer.Exit(code=1)
 
         issue = response.json()
         created.append(issue)
-        typer.echo(
+        typer_echo(
             f"Created: #{issue['number']} {issue['title']}"
         )
 

--- a/scaffoldr/local.py
+++ b/scaffoldr/local.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import typer
 
+from scaffoldr.exceptions import GitError, LocalError
 from scaffoldr.template_handler import (
     Template,
     load_template,
@@ -22,10 +23,9 @@ def _git(args: list[str], cwd: Path) -> None:
         text=True,
     )
     if result.returncode != 0:
-        typer.echo(
+        raise GitError(
             f"git error: {result.stderr.strip()}", err=True
         )
-        raise typer.Exit(code=1)
 
 
 def scaffold(
@@ -39,8 +39,7 @@ def scaffold(
     root = path / project_name
 
     if root.exists():
-        typer.echo(f"Error: {root} already exists.", err=True)
-        raise typer.Exit(code=1)
+        raise LocalError(f"Error: {root} already exists.")
 
     typer.echo(f"Creating project at {root} ...")
 

--- a/scaffoldr/new.py
+++ b/scaffoldr/new.py
@@ -8,7 +8,12 @@ from typer import Option as typer_option
 from typer import Typer
 from typer import echo as typer_echo
 
-from scaffoldr.exceptions import TemplateError
+from scaffoldr.exceptions import (
+    GitError,
+    GitHubError,
+    LocalError,
+    TemplateError,
+)
 from scaffoldr.github import (
     _get_token,
     get_authenticated_user,
@@ -65,61 +70,71 @@ def new(
     )
     try:
         _scaffold(project_name, template, path)
-    except TemplateError as e:
-        typer_echo(e, err=True)
-        raise typer_exit(code=1)
 
-    typer_echo("Creating GitHub repo...")
-    repo = _create_repo(
-        name=project_name,
-        description=description,
-        private=is_private,
-    )
-
-    root = path / project_name
-    ssh_url = repo["ssh_url"]
-    clone_url = repo["clone_url"]
-
-    if cfg.use_ssh:
-        remote_url = ssh_url
-    else:
-        token = _get_token()
-        remote_url = clone_url.replace(
-            "https://",
-            f"https://{cfg.github_username}:{token}@",
+        typer_echo("Creating GitHub repo...")
+        repo = _create_repo(
+            name=project_name,
+            description=description,
+            private=is_private,
         )
 
-    subprocess_run(
-        ["git", "remote", "add", "origin", remote_url],
-        cwd=root,
-        check=True,
-    )
-    subprocess_run(
-        ["git", "push", "-u", "origin", "main"],
-        cwd=root,
-        check=True,
-    )
+        root = path / project_name
+        ssh_url = repo["ssh_url"]
+        clone_url = repo["clone_url"]
 
-    if not cfg.use_ssh:
+        if cfg.use_ssh:
+            remote_url = ssh_url
+        else:
+            token = _get_token()
+            remote_url = clone_url.replace(
+                "https://",
+                f"https://{cfg.github_username}:{token}@",
+            )
+
         subprocess_run(
-            ["git", "remote", "set-url", "origin", clone_url],
+            ["git", "remote", "add", "origin", remote_url],
+            cwd=root,
+            check=True,
+        )
+        subprocess_run(
+            ["git", "push", "-u", "origin", "main"],
             cwd=root,
             check=True,
         )
 
-    with get_client() as client:
-        owner = get_authenticated_user(client)
-
-        typer_echo("Creating issues...")
-        _create_issues(owner, project_name, client)
-
-        if protect:
-            typer_echo("Setting branch protection...")
-            _protect_branch(
-                owner,
-                project_name,
-                client,
-                required_reviewers=cfg.required_reviewers,
+        if not cfg.use_ssh:
+            subprocess_run(
+                [
+                    "git",
+                    "remote",
+                    "set-url",
+                    "origin",
+                    clone_url,
+                ],
+                cwd=root,
+                check=True,
             )
 
-    typer_echo(f"Repo ready: {repo['html_url']}")
+        with get_client() as client:
+            owner = get_authenticated_user(client)
+
+            typer_echo("Creating issues...")
+            _create_issues(owner, project_name, client)
+
+            if protect:
+                typer_echo("Setting branch protection...")
+                _protect_branch(
+                    owner,
+                    project_name,
+                    client,
+                    required_reviewers=cfg.required_reviewers,
+                )
+        typer_echo(f"Repo ready: {repo['html_url']}")
+    except (
+        TemplateError,
+        GitHubError,
+        LocalError,
+        GitError,
+    ) as e:
+        typer_echo(e, err=True)
+        raise typer_exit(code=1)

--- a/scaffoldr/protection.py
+++ b/scaffoldr/protection.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-import typer
+from typer import echo as typer_echo
+
+from scaffoldr.exceptions import GitHubError
 
 
 def protect_branch(
@@ -34,14 +36,12 @@ def protect_branch(
         },
     )
     if not response.is_success:
-        typer.echo(
+        raise GitHubError(
             f"Error: Failed to set branch protection "
             f"- {response.status_code}: {response.text}",
-            err=True,
         )
-        raise typer.Exit(code=1)
 
-    typer.echo(
+    typer_echo(
         f"Branch protection enabled on '{branch}' "
         f" ({required_reviewers} reviewer(s) required)."
     )

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-# import click
 import pytest
+
+from scaffoldr.exceptions import GitHubError
 
 
 def test_create_repo_success():
@@ -45,7 +46,7 @@ def test_create_repo_already_exists():
     ):
         from scaffoldr.github import create_repo
 
-        with pytest.raises(Exception):
+        with pytest.raises(GitHubError):
             create_repo("myrepo")
 
 
@@ -63,7 +64,7 @@ def test_create_repo_invalid_token():
     ):
         from scaffoldr.github import create_repo
 
-        with pytest.raises(Exception):
+        with pytest.raises(GitHubError):
             create_repo("myrepo")
 
 
@@ -79,5 +80,5 @@ def test_no_token_raises():
     ):
         from scaffoldr.github import _get_token
 
-        with pytest.raises(Exception):
+        with pytest.raises(GitHubError):
             _get_token()

--- a/tests/test_issue_handler.py
+++ b/tests/test_issue_handler.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-# import click
 import pytest
 
+from scaffoldr.exceptions import GitHubError
 from scaffoldr.issue_handler import (
     DEFAULT_ISSUES,
     create_issues,
@@ -91,5 +91,5 @@ def test_create_issues_rate_limited():
         "scaffoldr.issue_handler._load_user_issues",
         return_value=[],
     ):
-        with pytest.raises(Exception):
+        with pytest.raises(GitHubError):
             create_issues("user", "repo", mock_client)

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
+from scaffoldr.exceptions import LocalError
 from scaffoldr.local import scaffold
 from scaffoldr.user_config import Config
 
@@ -56,13 +57,12 @@ def test_git_repo_initialized(project):
 
 
 def test_already_exists_raises(tmp_path):
-    # import click
 
     with patch(
         "scaffoldr.local.Config.load", return_value=DUMMY_CONFIG
     ):
         scaffold("myproject", "default", tmp_path)
-        with pytest.raises(Exception):
+        with pytest.raises(LocalError):
             scaffold("myproject", "default", tmp_path)
 
 

--- a/tests/test_protection.py
+++ b/tests/test_protection.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-# import click
 import pytest
 
+from scaffoldr.exceptions import GitHubError
 from scaffoldr.protection import protect_branch
 
 
@@ -50,11 +50,11 @@ def test_protect_branch_with_reviewers():
 
 def test_protect_branch_forbidden():
     client = _mock_client(403)
-    with pytest.raises(Exception):
+    with pytest.raises(GitHubError):
         protect_branch("user", "repo", client)
 
 
 def test_protect_branch_not_found():
     client = _mock_client(404)
-    with pytest.raises(Exception):
+    with pytest.raises(GitHubError):
         protect_branch("user", "repo", client)


### PR DESCRIPTION
## What
Replaced typer.Exit in business logic with custom exceptions
and isolated user-interaction to CLI layer.

## Changes
- `pyproject.toml`: removed `click` from dev-dependencies
- `scaffoldr/exceptions.py`: added `GitHubError`, `LocalError`,
  `GitError` custom exception classes
- `scaffoldr/github.py`: replaced `typer.Exit` with `GitHubError`
- `scaffoldr/issue_handler.py`: replaced `typer.Exit` with 
  `GitHubError`
- `scaffoldr/local.py`: replaced `typer.Exit` with 
   GitError/LocalError`
- `scaffoldr/protection.py`: replaced `typer.Exit` with 
  `GitHubError`
- `scaffoldr/init.py`: gracefully handled `GitError`/`GitHubError`/ 
  `LocalError`
- `scaffoldr/new.py`: gracefully handled `GitError`/`GitHubError`/ 
  `LocalError`
- `tests/`: replaced `Exception` with custom exceptions


## Why
To isolate user-interaction to the CLI layer.

## Impact
No breaking changes. Better error handling.

## Checklist
- [x] Closes #51 
- [x] CI green
- [x] All tests pass