### PR TITLE
fix: check config file existence before prompting in config init

### DIFF
--- a/scaffoldr/config/init.py
+++ b/scaffoldr/config/init.py
@@ -16,6 +16,16 @@ from scaffoldr.user_config import (
 app = Typer()
 
 
+@app.callback()
+def check_config_existence():
+    if CONFIG_FILE.exists():
+        overwrite = typer_confirm(
+            f"{CONFIG_FILE} already exists. Overwrite?"
+        )
+        if not overwrite:
+            raise typer_abort()
+
+
 @app.command()
 def init(
     author: Optional[str] = typer_option(
@@ -44,13 +54,6 @@ def init(
     ),
 ) -> None:
     """Create ~/.config/scaffoldr/config.toml interactively."""
-    if CONFIG_FILE.exists():
-        overwrite = typer_confirm(
-            f"{CONFIG_FILE} already exists. Overwrite?"
-        )
-        if not overwrite:
-            raise typer_abort()
-
     cfg = Config(
         author=author or "",
         github_username=github_username or "",


### PR DESCRIPTION
## What
Moved config existence check to callback that executes before
users see prompts.

## Changes
- `scaffoldr/config/init.py`: added callback function to check 
  config existence

## Why
Checking config existence before users see any prompts is
better UX.

## Impact
Non-breaking. Users are prompted for overwrite confirmation
before any input is requested.

## Checklist
- [x] Closes #43 
- [x] CI green
- [x] All tests pass