### PR TITLE
refactor: remove typer.echo progress feedback from business logic

### DIFF
--- a/scaffoldr/init.py
+++ b/scaffoldr/init.py
@@ -30,7 +30,7 @@ def init(
 ) -> None:
     """Scaffold a new project locally."""
     try:
-        _scaffold(project_name, template, path)
+        _scaffold(project_name, template, path, typer_echo)
     except (TemplateError, LocalError, GitError) as e:
         typer_echo(e, err=True)
         raise typer_exit(code=1)

--- a/scaffoldr/issue_handler.py
+++ b/scaffoldr/issue_handler.py
@@ -5,7 +5,7 @@ try:
 except ImportError:
     import tomli as tomllib
 
-from typer import echo as typer_echo
+from collections.abc import Callable
 
 from scaffoldr.exceptions import GitHubError
 from scaffoldr.user_config import CONFIG_DIR
@@ -76,7 +76,12 @@ def resolve_templates() -> list[dict]:
     return merged
 
 
-def create_issues(owner: str, repo: str, client) -> list[dict]:
+def create_issues(
+    owner: str,
+    repo: str,
+    client,
+    progress: Callable[[str], None] = lambda _: None,
+) -> list[dict]:
     """
     Create issues on a GitHub repo using resolved templates.
     Returns list of created issue dicts.
@@ -112,7 +117,7 @@ def create_issues(owner: str, repo: str, client) -> list[dict]:
 
         issue = response.json()
         created.append(issue)
-        typer_echo(
+        progress(
             f"Created: #{issue['number']} {issue['title']}"
         )
 

--- a/scaffoldr/issues/create.py
+++ b/scaffoldr/issues/create.py
@@ -25,5 +25,7 @@ def create(
             repo_name = repo
 
         typer_echo(f"Creating issues on {owner}/{repo_name}...")
-        created = _create_issues(owner, repo_name, client)
+        created = _create_issues(
+            owner, repo_name, client, typer_echo
+        )
         typer_echo(f"Done. {len(created)} issues created.")

--- a/scaffoldr/local.py
+++ b/scaffoldr/local.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 import subprocess
+from collections.abc import Callable
 from pathlib import Path
-
-import typer
 
 from scaffoldr.exceptions import GitError, LocalError
 from scaffoldr.template_handler import (
@@ -29,7 +28,10 @@ def _git(args: list[str], cwd: Path) -> None:
 
 
 def scaffold(
-    project_name: str, template_name: str, path: Path
+    project_name: str,
+    template_name: str,
+    path: Path,
+    progress: Callable[[str], None] = lambda _: None,
 ) -> None:
     """
     Create a new project at path/project_name with
@@ -41,7 +43,7 @@ def scaffold(
     if root.exists():
         raise LocalError(f"Error: {root} already exists.")
 
-    typer.echo(f"Creating project at {root} ...")
+    progress(f"Creating project at {root} ...")
 
     scaffold_variables = {
         "project_name": project_name,
@@ -66,4 +68,4 @@ def scaffold(
     _git(["add", "."], cwd=root)
     _git(["commit", "-m", "chore: initial scaffold"], cwd=root)
 
-    typer.echo(f"Done. Project ready at {root}")
+    progress(f"Done. Project ready at {root}")

--- a/scaffoldr/new.py
+++ b/scaffoldr/new.py
@@ -69,7 +69,7 @@ def new(
         private if private is not None else cfg.default_private
     )
     try:
-        _scaffold(project_name, template, path)
+        _scaffold(project_name, template, path, typer_echo)
 
         typer_echo("Creating GitHub repo...")
         repo = _create_repo(

--- a/scaffoldr/new.py
+++ b/scaffoldr/new.py
@@ -130,6 +130,7 @@ def new(
                     project_name,
                     client,
                     required_reviewers=cfg.required_reviewers,
+                    progress=typer_echo,
                 )
         typer_echo(f"Repo ready: {repo['html_url']}")
     except (

--- a/scaffoldr/new.py
+++ b/scaffoldr/new.py
@@ -119,7 +119,9 @@ def new(
             owner = get_authenticated_user(client)
 
             typer_echo("Creating issues...")
-            _create_issues(owner, project_name, client)
+            _create_issues(
+                owner, project_name, client, typer_echo
+            )
 
             if protect:
                 typer_echo("Setting branch protection...")

--- a/scaffoldr/protection.py
+++ b/scaffoldr/protection.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typer import echo as typer_echo
+from collections.abc import Callable
 
 from scaffoldr.exceptions import GitHubError
 
@@ -11,6 +11,7 @@ def protect_branch(
     client,
     branch: str = "main",
     required_reviewers: int = 1,
+    progress: Callable[[str], None] = lambda _: None,
 ) -> None:
     """
     Apply branch protection rules to the given branch.
@@ -41,7 +42,7 @@ def protect_branch(
             f"- {response.status_code}: {response.text}",
         )
 
-    typer_echo(
+    progress(
         f"Branch protection enabled on '{branch}' "
         f" ({required_reviewers} reviewer(s) required)."
     )


### PR DESCRIPTION
## What
Removed `typer.echo` from business logic modules, decoupling
them from the CLI layer.

## Changes
- `scaffoldr/local.py`: replaced `typer.echo` with a callback
  lambda function
- `scaffoldr/issue_handler.py`: replaced `typer.echo` with a 
  callback lambda function
- `scaffoldr/protection.py`: replaced `typer.echo` with a callback
  lambda function
- `scaffoldr/issues/create.py`: pass `typer.echo` as progress
  callback to `create_issues` 
- `scaffoldr/init.py`: pass `typer.echo` as progress
  callback to `scaffold` 
- `scaffoldr/new.py`: pass `typer.echo` as progress
  callback to `scaffold`, `create_issues` and `protect_branch` 

## Why
To isolate user-interaction to the CLI layer.

## Impact
No breaking changes. Decoupling business logic from CLI layer.

## Checklist
- [x] Closes #54 
- [x] CI green
- [x] All tests pass