### PR TITLE
refactor: move _git helper to utils.py

### DIFF
--- a/scaffoldr/local.py
+++ b/scaffoldr/local.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from pathlib import Path
-from subprocess import run as subprocess_run
 
-from scaffoldr.exceptions import GitError, LocalError
+from scaffoldr.exceptions import LocalError
 from scaffoldr.template_handler import (
     Template,
     load_template,
@@ -12,17 +11,7 @@ from scaffoldr.template_handler import (
     resolve_template_path,
 )
 from scaffoldr.user_config import Config
-
-
-def _git(args: list[str], cwd: Path) -> None:
-    result = subprocess_run(
-        ["git", *args],
-        cwd=cwd,
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        raise GitError(f"git error: {result.stderr.strip()}")
+from scaffoldr.utils import _git
 
 
 def scaffold(

--- a/scaffoldr/new.py
+++ b/scaffoldr/new.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from subprocess import run as subprocess_run
 from typing import Optional
 
 from typer import Argument as typer_argument
@@ -30,6 +29,7 @@ from scaffoldr.protection import (
     protect_branch as _protect_branch,
 )
 from scaffoldr.user_config import Config
+from scaffoldr.utils import _git
 
 app = Typer(
     help=(
@@ -91,28 +91,24 @@ def new(
                 f"https://{cfg.github_username}:{token}@",
             )
 
-        subprocess_run(
-            ["git", "remote", "add", "origin", remote_url],
+        _git(
+            ["remote", "add", "origin", remote_url],
             cwd=root,
-            check=True,
         )
-        subprocess_run(
-            ["git", "push", "-u", "origin", "main"],
+        _git(
+            ["push", "-u", "origin", "main"],
             cwd=root,
-            check=True,
         )
 
         if not cfg.use_ssh:
-            subprocess_run(
+            _git(
                 [
-                    "git",
                     "remote",
                     "set-url",
                     "origin",
                     clone_url,
                 ],
                 cwd=root,
-                check=True,
             )
 
         with get_client() as client:

--- a/scaffoldr/utils.py
+++ b/scaffoldr/utils.py
@@ -1,12 +1,25 @@
 from pathlib import Path
+from subprocess import run as subprocess_run
 
 from typer import Abort as typer_abort
 from typer import echo as typer_echo
 
+from scaffoldr.exceptions import GitError
 from scaffoldr.user_config import (
     CONFIG_DIR,
     USER_DEFINED_TEMPLATES_PATH,
 )
+
+
+def _git(args: list[str], cwd: Path) -> None:
+    result = subprocess_run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise GitError(f"git error: {result.stderr.strip()}")
 
 
 def check_legacy_config():

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -26,22 +26,6 @@ def project(tmp_path):
     return tmp_path / "myproject"
 
 
-def test_git_error_in_git_command_runner(tmp_path):
-    args = ["asdf"]
-    result = MagicMock()
-    result.returncode = 1
-    result.stderr = "some error"
-
-    with patch(
-        "scaffoldr.local.subprocess_run",
-        return_value=result,
-    ):
-        with pytest.raises(
-            GitError, match="git error: some error"
-        ):
-            _git(args, tmp_path)
-
-
 def test_folders_created(project):
     assert (project / "myproject").is_dir()
     assert (project / "tests").is_dir()

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
-from scaffoldr.exceptions import GitError, LocalError
-from scaffoldr.local import _git, scaffold
+from scaffoldr.exceptions import LocalError
+from scaffoldr.local import scaffold
 from scaffoldr.user_config import Config
 
 DUMMY_CONFIG = Config(

--- a/tests/test_new.py
+++ b/tests/test_new.py
@@ -25,13 +25,11 @@ def mock_config(monkeypatch):
 
 
 @pytest_fixture
-def mock_subprocess_run(monkeypatch):
-    mock_subprocess_run = MagicMock()
+def mock_git_cmd_runner(monkeypatch):
+    git_cmd_runner = MagicMock()
 
-    monkeypatch.setattr(
-        "scaffoldr.new.subprocess_run", mock_subprocess_run
-    )
-    return mock_subprocess_run
+    monkeypatch.setattr("scaffoldr.new._git", git_cmd_runner)
+    return git_cmd_runner
 
 
 @pytest_fixture
@@ -75,7 +73,7 @@ def test_new_use_ssh(
     tmp_path,
     monkeypatch,
     mock_config,
-    mock_subprocess_run,
+    mock_git_cmd_runner,
     mock_github_deps,
 ):
     mock_repo = mock_github_deps
@@ -103,7 +101,7 @@ def test_new_do_not_use_ssh(
     tmp_path,
     monkeypatch,
     mock_config,
-    mock_subprocess_run,
+    mock_git_cmd_runner,
     mock_github_deps,
 ):
     mock_repo = mock_github_deps
@@ -127,28 +125,24 @@ def test_new_do_not_use_ssh(
         f"Repo ready: {mock_repo['html_url']}\n"
     ) in result.output
 
-    assert len(mock_subprocess_run.call_args_list) == 3
-    assert mock_subprocess_run.call_args_list[0] == call(
+    assert len(mock_git_cmd_runner.call_args_list) == 3
+    assert mock_git_cmd_runner.call_args_list[0] == call(
         [
-            "git",
             "remote",
             "add",
             "origin",
             "https://user:token@github.com/user/repo.git",
         ],
         cwd=tmp_path / "foo",
-        check=True,
     )
-    assert mock_subprocess_run.call_args_list[2] == call(
+    assert mock_git_cmd_runner.call_args_list[2] == call(
         [
-            "git",
             "remote",
             "set-url",
             "origin",
             "https://github.com/user/repo.git",
         ],
         cwd=tmp_path / "foo",
-        check=True,
     )
 
 
@@ -156,7 +150,7 @@ def test_new_do_not_protect_branch(
     tmp_path,
     monkeypatch,
     mock_config,
-    mock_subprocess_run,
+    mock_git_cmd_runner,
     mock_github_deps,
 ):
     mock_repo = mock_github_deps
@@ -186,7 +180,7 @@ def test_new_raises_exception(
     tmp_path,
     monkeypatch,
     mock_config,
-    mock_subprocess_run,
+    mock_git_cmd_runner,
     mock_github_deps,
 ):
     monkeypatch.setattr(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,6 +27,18 @@ def test_git_error_in_git_command_runner(tmp_path):
             _git(args, tmp_path)
 
 
+def test_git_cmd_runner_happy_path(tmp_path, monkeypatch):
+    args = ["init"]
+    result = MagicMock()
+    result.returncode = 0
+
+    monkeypatch.setattr(
+        "scaffoldr.utils.subprocess_run",
+        lambda *a, **kw: result,
+    )
+    _git(args, cwd=tmp_path)
+
+
 def test_ensure_dirs_success(tmp_path, monkeypatch):
     user_templates = tmp_path / "templates"
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,30 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from typer import Abort as typer_abort
 
-from scaffoldr.utils import check_legacy_config, ensure_dirs
+from scaffoldr.exceptions import GitError
+from scaffoldr.utils import (
+    _git,
+    check_legacy_config,
+    ensure_dirs,
+)
+
+
+def test_git_error_in_git_command_runner(tmp_path):
+    args = ["asdf"]
+    result = MagicMock()
+    result.returncode = 1
+    result.stderr = "some error"
+
+    with patch(
+        "scaffoldr.utils.subprocess_run",
+        return_value=result,
+    ):
+        with pytest.raises(
+            GitError, match="git error: some error"
+        ):
+            _git(args, tmp_path)
 
 
 def test_ensure_dirs_success(tmp_path, monkeypatch):


### PR DESCRIPTION
## What
Moved `_git` from `local.py` to `utils.py`.

## Changes
- `scaffoldr/local.py`: removed `_git` function and added import
  for `_git` function
- `tests/test_utils.py`: added happy path test for `_git` and
  moved `GitError` test from `test_local.py`
- `tests/test_local.py`: removed `GitError` test for `_git` 
- `scaffoldr/utils.py`: moved `_git` function from `local.py`
- `scaffoldr/new.py`: modified `new` to use `_git` command runner
- `tests/test_new.py`: modified tests to expect `_git` command 
  runner

## Why
`_git` is a generic git command runner that doesn't belong in 
`local.py`. It should live in `utils.py` alongside other app-level
utilities.

## Impact
No breaking changes. Better separation of concerns.

## Checklist 
- [x] All tests pass
- [x] CI green
- [x] Closes #60 