### PR TITLE
fix: move overwrite check to fn body; use explicit prompts for fields

### DIFF
--- a/scaffoldr/config/init.py
+++ b/scaffoldr/config/init.py
@@ -5,6 +5,7 @@ from typer import Option as typer_option
 from typer import Typer
 from typer import confirm as typer_confirm
 from typer import echo as typer_echo
+from typer import prompt as typer_prompt
 
 from scaffoldr.user_config import (
     CONFIG_FILE,
@@ -16,8 +17,32 @@ from scaffoldr.user_config import (
 app = Typer()
 
 
-@app.callback()
-def check_config_existence():
+@app.command()
+def init(
+    author: Optional[str] = typer_option(
+        None, help="Author name"
+    ),
+    github_username: Optional[str] = typer_option(
+        None, help="GitHub username"
+    ),
+    license: Optional[str] = typer_option(None, help="License"),
+    python_version: Optional[str] = typer_option(
+        None, help="Python version"
+    ),
+    default_private: Optional[bool] = typer_option(
+        None, help="Private repos by default?"
+    ),
+    github_token: Optional[str] = typer_option(
+        None, help="GitHub token (leave blank to skip)"
+    ),
+    required_reviewers: Optional[int] = typer_option(
+        None, help="Required PR reviewers"
+    ),
+    use_ssh: Optional[bool] = typer_option(
+        None, help="Use SSH for git remote?"
+    ),
+) -> None:
+    """Create ~/.config/scaffoldr/config.toml interactively."""
     if CONFIG_FILE.exists():
         overwrite = typer_confirm(
             f"{CONFIG_FILE} already exists. Overwrite?"
@@ -25,35 +50,43 @@ def check_config_existence():
         if not overwrite:
             raise typer_abort()
 
+    if author is None:
+        author = typer_prompt("Author name")
 
-@app.command()
-def init(
-    author: Optional[str] = typer_option(
-        None, prompt="Author name"
-    ),
-    github_username: Optional[str] = typer_option(
-        None, prompt="GitHub username"
-    ),
-    license: str = typer_option(
-        DEFAULT_LICENSE, prompt="License"
-    ),
-    python_version: str = typer_option(
-        DEFAULT_PYTHON_VERSION, prompt="Python version"
-    ),
-    default_private: bool = typer_option(
-        False, prompt="Private repos by default?"
-    ),
-    github_token: str = typer_option(
-        "", prompt="GitHub token (leave blank to skip)"
-    ),
-    required_reviewers: int = typer_option(
-        1, prompt="Required PR reviewers"
-    ),
-    use_ssh: bool = typer_option(
-        True, prompt="Use SSH for git remote?"
-    ),
-) -> None:
-    """Create ~/.config/scaffoldr/config.toml interactively."""
+    if github_username is None:
+        github_username = typer_prompt("GitHub username")
+
+    if license is None:
+        license = typer_prompt(
+            "License", default=DEFAULT_LICENSE
+        )
+
+    if python_version is None:
+        python_version = typer_prompt(
+            "Python version",
+            default=DEFAULT_PYTHON_VERSION,
+        )
+
+    if default_private is None:
+        default_private = typer_prompt(
+            "Private repos by default?", default=False
+        )
+
+    if github_token is None:
+        github_token = typer_prompt(
+            "GitHub token (leave blank to skip)", default=""
+        )
+
+    if required_reviewers is None:
+        required_reviewers = typer_prompt(
+            "Required PR reviewers", default=1
+        )
+
+    if use_ssh is None:
+        use_ssh = typer_prompt(
+            "Use SSH for git remote?", default=True
+        )
+
     cfg = Config(
         author=author or "",
         github_username=github_username or "",

--- a/tests/config/test_init.py
+++ b/tests/config/test_init.py
@@ -1,30 +1,30 @@
 from typer.testing import CliRunner
 
 from scaffoldr.main import app
+from tests.conftest import strip_ansi
 
 runner = CliRunner()
 
 
-# addressed in #61
-# def test_init_config_file_overwrite_denied(
-#     tmp_path, monkeypatch
-# ):
-#     config_dir = tmp_path / ".config" / "scaffoldr"
-#     config_dir.mkdir(parents=True, exist_ok=True)
-#
-#     config_file = config_dir / "config.toml"
-#     config_file.write_text('foo="bar"')
-#
-#     monkeypatch.setattr(
-#         "scaffoldr.config.init.CONFIG_FILE", config_file
-#     )
-#
-#     result = runner.invoke(app, ["config", "init"],
-#               input="n\n")
-#
-#     assert (
-#         f"{config_file} already exists. Overwrite?\nAborted."
-#     ) in result.output
+def test_init_config_file_overwrite_denied(
+    tmp_path, monkeypatch
+):
+    config_dir = tmp_path / ".config" / "scaffoldr"
+    config_dir.mkdir(parents=True, exist_ok=True)
+
+    config_file = config_dir / "config.toml"
+    config_file.write_text('foo="bar"')
+
+    monkeypatch.setattr(
+        "scaffoldr.config.init.CONFIG_FILE", config_file
+    )
+
+    result = runner.invoke(app, ["config", "init"], input="n\n")
+
+    assert (
+        f"{config_file} already exists. "
+        "Overwrite? [y/N]: n\nAborted."
+    ) in strip_ansi(result.output)
 
 
 def test_init_happy_path(tmp_path, monkeypatch):


### PR DESCRIPTION
## What
Overwrite check was in a callback. It was moved to the start of
the function body, along with explicit prompts for fields.

## Changes
- `scaffoldr/config/init.py`: moved overwrite check to start of
  function body; used explicit prompts for fields
- `tests/config/test_init.py`: added test for overwrite denied
  when file exists

## Why
`callback` parameter is not supported by `Typer` when using `add_typer` without a name; overwrite check was firing incorrectly.
Moving it to body fixes UX -u sers are now correctly prompted for
overwrite confirmation before any input is requested.

## Impact
No breaking changes. CLI behavior unchanged for users that
don't have an existing config file.

## Checklist
- [x] All tests pass
- [x] CI green
- [x] Closes #61 