### PR TITLE
feat: --dry-run flag on new and init commands

### DIFF
--- a/scaffoldr/github.py
+++ b/scaffoldr/github.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Callable
 
 import httpx
 
@@ -93,3 +94,37 @@ def get_authenticated_user(client: httpx.Client) -> str:
             " your token.",
         )
     return response.json()["login"]
+
+
+def dry_run_github_ops(
+    project_name: str,
+    protect: bool,
+    use_ssh: bool,
+    progress: Callable[[str], None] = lambda _: None,
+) -> None:
+    progress(
+        f"[dry-run] Would create GitHub repo: {project_name}"
+    )
+
+    progress(
+        "[dry-run] Would run: git remote add "
+        "origin <remote-url>"
+    )
+
+    progress("[dry-run] Would run: git push -u origin main")
+
+    if not use_ssh:
+        progress(
+            "[dry-run] Would run: git remote set-url "
+            "origin <clone-url>"
+        )
+
+    progress(
+        "[dry-run] Would create default issues for: "
+        f"{project_name}"
+    )
+
+    if protect:
+        progress(
+            "[dry-run] Would enable branch protection on: main"
+        )

--- a/scaffoldr/init.py
+++ b/scaffoldr/init.py
@@ -11,8 +11,12 @@ from scaffoldr.exceptions import (
     LocalError,
     TemplateError,
 )
-from scaffoldr.local import scaffold as _scaffold
-from scaffoldr.utils import dry_run_scaffold
+from scaffoldr.local import (
+    dry_run_scaffold,
+)
+from scaffoldr.local import (
+    scaffold as _scaffold,
+)
 
 app = Typer(help="Scaffold a new project locally.")
 

--- a/scaffoldr/init.py
+++ b/scaffoldr/init.py
@@ -12,6 +12,7 @@ from scaffoldr.exceptions import (
     TemplateError,
 )
 from scaffoldr.local import scaffold as _scaffold
+from scaffoldr.utils import dry_run_scaffold
 
 app = Typer(help="Scaffold a new project locally.")
 
@@ -27,10 +28,22 @@ def init(
     path: Path = typer_option(
         Path("."), help="Where to create the project"
     ),
+    dry_run: bool = typer_option(
+        False,
+        help=(
+            "Print what would happen without filesystem "
+            "changes."
+        ),
+    ),
 ) -> None:
     """Scaffold a new project locally."""
     try:
-        _scaffold(project_name, template, path, typer_echo)
+        if dry_run:
+            dry_run_scaffold(
+                project_name, template, path, typer_echo
+            )
+        else:
+            _scaffold(project_name, template, path, typer_echo)
     except (TemplateError, LocalError, GitError) as e:
         typer_echo(e, err=True)
         raise typer_exit(code=1)

--- a/scaffoldr/local.py
+++ b/scaffoldr/local.py
@@ -11,7 +11,7 @@ from scaffoldr.template_handler import (
     resolve_template_path,
 )
 from scaffoldr.user_config import Config
-from scaffoldr.utils import _git
+from scaffoldr.utils import _git, build_scaffold_variables
 
 
 def scaffold(
@@ -32,12 +32,9 @@ def scaffold(
 
     progress(f"Creating project at {root} ...")
 
-    scaffold_variables = {
-        "project_name": project_name,
-        "author": cfg.author,
-        "python_version": cfg.python_version,
-        "license_": cfg.license,
-    }
+    scaffold_variables = build_scaffold_variables(
+        project_name, cfg
+    )
 
     template_path = resolve_template_path(template_name)
     template: Template = load_template(template_path)

--- a/scaffoldr/local.py
+++ b/scaffoldr/local.py
@@ -53,3 +53,38 @@ def scaffold(
     _git(["commit", "-m", "chore: initial scaffold"], cwd=root)
 
     progress(f"Done. Project ready at {root}")
+
+
+def dry_run_scaffold(
+    project_name: str,
+    template_name: str,
+    path: Path,
+    progress: Callable[[str], None] = lambda _: None,
+) -> None:
+    cfg = Config.load()
+
+    root = path / project_name
+
+    if root.exists():
+        raise LocalError(f"Error: {root} already exists.")
+
+    scaffold_variables = build_scaffold_variables(
+        project_name, cfg
+    )
+
+    template_path = resolve_template_path(template_name)
+    template: Template = load_template(template_path)
+    rendered_template = render_template(
+        template, scaffold_variables
+    )
+
+    for path_str, _ in rendered_template.items():
+        progress(f"[dry-run] Would create: {(root / path_str)}")
+
+    # git
+    progress(f"[dry-run] @{root}: git init")
+    progress(f"[dry-run] @{root}: git add .")
+    progress(
+        f'[dry-run] @{root}: git commit -m "chore: '
+        'initial scaffold"'
+    )

--- a/scaffoldr/new.py
+++ b/scaffoldr/new.py
@@ -15,6 +15,7 @@ from scaffoldr.exceptions import (
 )
 from scaffoldr.github import (
     _get_token,
+    dry_run_github_ops,
     get_authenticated_user,
     get_client,
 )
@@ -24,7 +25,12 @@ from scaffoldr.github import (
 from scaffoldr.issue_handler import (
     create_issues as _create_issues,
 )
-from scaffoldr.local import scaffold as _scaffold
+from scaffoldr.local import (
+    dry_run_scaffold,
+)
+from scaffoldr.local import (
+    scaffold as _scaffold,
+)
 from scaffoldr.protection import (
     protect_branch as _protect_branch,
 )
@@ -59,6 +65,13 @@ def new(
     protect: bool = typer_option(
         True, help="Enable branch protection on main."
     ),
+    dry_run: bool = typer_option(
+        False,
+        help=(
+            "Print what would happen without filesystem "
+            "changes or calling GitHub."
+        ),
+    ),
 ) -> None:
     """
     Scaffold a new project locally and create a
@@ -69,66 +82,76 @@ def new(
         private if private is not None else cfg.default_private
     )
     try:
-        _scaffold(project_name, template, path, typer_echo)
-
-        typer_echo("Creating GitHub repo...")
-        repo = _create_repo(
-            name=project_name,
-            description=description,
-            private=is_private,
-        )
-
-        root = path / project_name
-        ssh_url = repo["ssh_url"]
-        clone_url = repo["clone_url"]
-
-        if cfg.use_ssh:
-            remote_url = ssh_url
-        else:
-            token = _get_token()
-            remote_url = clone_url.replace(
-                "https://",
-                f"https://{cfg.github_username}:{token}@",
+        if dry_run:
+            dry_run_scaffold(
+                project_name, template, path, typer_echo
             )
 
-        _git(
-            ["remote", "add", "origin", remote_url],
-            cwd=root,
-        )
-        _git(
-            ["push", "-u", "origin", "main"],
-            cwd=root,
-        )
+            dry_run_github_ops(
+                project_name, protect, cfg.use_ssh, typer_echo
+            )
 
-        if not cfg.use_ssh:
+        else:
+            _scaffold(project_name, template, path, typer_echo)
+
+            typer_echo("Creating GitHub repo...")
+            repo = _create_repo(
+                name=project_name,
+                description=description,
+                private=is_private,
+            )
+
+            root = path / project_name
+            ssh_url = repo["ssh_url"]
+            clone_url = repo["clone_url"]
+
+            if cfg.use_ssh:
+                remote_url = ssh_url
+            else:
+                token = _get_token()
+                remote_url = clone_url.replace(
+                    "https://",
+                    f"https://{cfg.github_username}:{token}@",
+                )
+
             _git(
-                [
-                    "remote",
-                    "set-url",
-                    "origin",
-                    clone_url,
-                ],
+                ["remote", "add", "origin", remote_url],
+                cwd=root,
+            )
+            _git(
+                ["push", "-u", "origin", "main"],
                 cwd=root,
             )
 
-        with get_client() as client:
-            owner = get_authenticated_user(client)
-
-            typer_echo("Creating issues...")
-            _create_issues(
-                owner, project_name, client, typer_echo
-            )
-
-            if protect:
-                typer_echo("Setting branch protection...")
-                _protect_branch(
-                    owner,
-                    project_name,
-                    client,
-                    required_reviewers=cfg.required_reviewers,
-                    progress=typer_echo,
+            if not cfg.use_ssh:
+                _git(
+                    [
+                        "remote",
+                        "set-url",
+                        "origin",
+                        clone_url,
+                    ],
+                    cwd=root,
                 )
-        typer_echo(f"Repo ready: {repo['html_url']}")
+
+            with get_client() as client:
+                owner = get_authenticated_user(client)
+
+                typer_echo("Creating issues...")
+                _create_issues(
+                    owner, project_name, client, typer_echo
+                )
+
+                if protect:
+                    typer_echo("Setting branch protection...")
+                    _protect_branch(
+                        owner,
+                        project_name,
+                        client,
+                        required_reviewers=cfg.required_reviewers,
+                        progress=typer_echo,
+                    )
+            typer_echo(f"Repo ready: {repo['html_url']}")
     except (
         TemplateError,
         GitHubError,

--- a/scaffoldr/utils.py
+++ b/scaffoldr/utils.py
@@ -8,6 +8,7 @@ from scaffoldr.exceptions import GitError
 from scaffoldr.user_config import (
     CONFIG_DIR,
     USER_DEFINED_TEMPLATES_PATH,
+    Config,
 )
 
 
@@ -39,3 +40,14 @@ def ensure_dirs():
     USER_DEFINED_TEMPLATES_PATH.mkdir(
         parents=True, exist_ok=True
     )
+
+
+def build_scaffold_variables(
+    project_name: str, cfg: Config
+) -> dict[str, str]:
+    return {
+        "project_name": project_name,
+        "author": cfg.author,
+        "python_version": cfg.python_version,
+        "license_": cfg.license,
+    }

--- a/scaffoldr/utils.py
+++ b/scaffoldr/utils.py
@@ -1,17 +1,10 @@
-from collections.abc import Callable
 from pathlib import Path
 from subprocess import run as subprocess_run
 
 from typer import Abort as typer_abort
 from typer import echo as typer_echo
 
-from scaffoldr.exceptions import GitError, LocalError
-from scaffoldr.template_handler import (
-    Template,
-    load_template,
-    render_template,
-    resolve_template_path,
-)
+from scaffoldr.exceptions import GitError
 from scaffoldr.user_config import (
     CONFIG_DIR,
     USER_DEFINED_TEMPLATES_PATH,
@@ -58,38 +51,3 @@ def build_scaffold_variables(
         "python_version": cfg.python_version,
         "license_": cfg.license,
     }
-
-
-def dry_run_scaffold(
-    project_name: str,
-    template_name: str,
-    path: Path,
-    progress: Callable[[str], None] = lambda _: None,
-) -> None:
-    cfg = Config.load()
-
-    root = path / project_name
-
-    if root.exists():
-        raise LocalError(f"Error: {root} already exists.")
-
-    scaffold_variables = build_scaffold_variables(
-        project_name, cfg
-    )
-
-    template_path = resolve_template_path(template_name)
-    template: Template = load_template(template_path)
-    rendered_template = render_template(
-        template, scaffold_variables
-    )
-
-    for path_str, _ in rendered_template.items():
-        progress(f"[dry-run] Would create: {(root / path_str)}")
-
-    # git
-    progress(f"[dry-run] @{root}: git init")
-    progress(f"[dry-run] @{root}: git add .")
-    progress(
-        f'[dry-run] @{root}: git commit -m "chore: '
-        'initial scaffold"'
-    )

--- a/scaffoldr/utils.py
+++ b/scaffoldr/utils.py
@@ -1,10 +1,17 @@
+from collections.abc import Callable
 from pathlib import Path
 from subprocess import run as subprocess_run
 
 from typer import Abort as typer_abort
 from typer import echo as typer_echo
 
-from scaffoldr.exceptions import GitError
+from scaffoldr.exceptions import GitError, LocalError
+from scaffoldr.template_handler import (
+    Template,
+    load_template,
+    render_template,
+    resolve_template_path,
+)
 from scaffoldr.user_config import (
     CONFIG_DIR,
     USER_DEFINED_TEMPLATES_PATH,
@@ -51,3 +58,38 @@ def build_scaffold_variables(
         "python_version": cfg.python_version,
         "license_": cfg.license,
     }
+
+
+def dry_run_scaffold(
+    project_name: str,
+    template_name: str,
+    path: Path,
+    progress: Callable[[str], None] = lambda _: None,
+) -> None:
+    cfg = Config.load()
+
+    root = path / project_name
+
+    if root.exists():
+        raise LocalError(f"Error: {root} already exists.")
+
+    scaffold_variables = build_scaffold_variables(
+        project_name, cfg
+    )
+
+    template_path = resolve_template_path(template_name)
+    template: Template = load_template(template_path)
+    rendered_template = render_template(
+        template, scaffold_variables
+    )
+
+    for path_str, _ in rendered_template.items():
+        progress(f"[dry-run] Would create: {(root / path_str)}")
+
+    # git
+    progress(f"[dry-run] @{root}: git init")
+    progress(f"[dry-run] @{root}: git add .")
+    progress(
+        f'[dry-run] @{root}: git commit -m "chore: '
+        'initial scaffold"'
+    )

--- a/tests/config/test_show.py
+++ b/tests/config/test_show.py
@@ -1,5 +1,3 @@
-from unittest.mock import MagicMock, patch
-
 from typer.testing import CliRunner
 
 from scaffoldr.main import app
@@ -7,31 +5,19 @@ from scaffoldr.main import app
 runner = CliRunner()
 
 
-def test_show_success(tmp_path):
-    mock_config = MagicMock()
-    mock_config.author = "test_author"
-    mock_config.github_username = "test_username"
-    mock_config.python_version = "test_version"
-    mock_config.license = "test_license"
-    mock_config.default_private = False
-    mock_config.required_reviewers = 1
-    mock_config.use_ssh = True
-    mock_config.github_token = ""
+def test_show_success(tmp_path, make_mock_config):
+    _ = make_mock_config("scaffoldr.config.show.Config.load")
 
-    with patch(
-        "scaffoldr.config.show.Config.load",
-        return_value=mock_config,
-    ):
-        result = runner.invoke(app, ["config", "show"])
+    result = runner.invoke(app, ["config", "show"])
 
-        assert result.exit_code == 0
-        assert (
-            "author             = 'test_author'\n"
-            "github_username    = 'test_username'\n"
-            "python_version     = 'test_version'\n"
-            "license            = 'test_license'\n"
-            "default_private    = False\n"
-            "required_reviewers = 1\n"
-            "use_ssh            = True\n"
-            "github_token       = (not set)"
-        ) in result.output
+    assert result.exit_code == 0
+    assert (
+        "author             = 'test_author'\n"
+        "github_username    = 'user'\n"
+        "python_version     = 'test_version'\n"
+        "license            = 'test_license'\n"
+        "default_private    = True\n"
+        "required_reviewers = 1\n"
+        "use_ssh            = True\n"
+        "github_token       = toke****\n"
+    ) in result.output

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,26 @@
 from re import compile as re_compile
+from unittest.mock import MagicMock
+
+import pytest
 
 ANSI_ESCAPE = re_compile(r"\x1b\[[0-9;]*m")
 
 
 def strip_ansi(text: str) -> str:
     return ANSI_ESCAPE.sub("", text)
+
+
+@pytest.fixture
+def make_mock_config(monkeypatch):
+    def _make(patch_target: str):
+        config = MagicMock()
+        config.default_private = True
+        config.use_ssh = True
+        config.github_username = "user"
+        config.required_reviewers = 1
+        config.github_token = "token"
+
+        monkeypatch.setattr(patch_target, lambda: config)
+        return config
+
+    return _make

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,14 +13,18 @@ def strip_ansi(text: str) -> str:
 @pytest.fixture
 def make_mock_config(monkeypatch):
     def _make(patch_target: str):
-        config = MagicMock()
-        config.default_private = True
-        config.use_ssh = True
-        config.github_username = "user"
-        config.required_reviewers = 1
-        config.github_token = "token"
+        mock_config = MagicMock()
 
-        monkeypatch.setattr(patch_target, lambda: config)
-        return config
+        mock_config.author = "test_author"
+        mock_config.github_username = "user"
+        mock_config.python_version = "test_version"
+        mock_config.license = "test_license"
+        mock_config.default_private = True
+        mock_config.required_reviewers = 1
+        mock_config.use_ssh = True
+        mock_config.github_token = "token"
+
+        monkeypatch.setattr(patch_target, lambda: mock_config)
+        return mock_config
 
     return _make

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -8,6 +8,7 @@ from scaffoldr.exceptions import GitHubError
 from scaffoldr.github import (
     _get_token,
     create_repo,
+    dry_run_github_ops,
     get_authenticated_user,
     get_client,
 )
@@ -166,3 +167,24 @@ def test_get_authenticated_user_raises_on_error():
     ):
         get_authenticated_user(mock_client)
     mock_client.get.assert_called_once_with("/user")
+
+
+def test_dry_run_github_ops():
+    progress = []
+    dry_run_github_ops(
+        project_name="project",
+        protect=True,
+        use_ssh=False,
+        progress=progress.append,
+    )
+
+    assert progress == [
+        "[dry-run] Would create GitHub repo: project",
+        "[dry-run] Would run: git remote add "
+        "origin <remote-url>",
+        "[dry-run] Would run: git push -u origin main",
+        "[dry-run] Would run: git remote set-url origin "
+        "<clone-url>",
+        "[dry-run] Would create default issues for: project",
+        "[dry-run] Would enable branch protection on: main",
+    ]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,9 +1,30 @@
+from unittest.mock import MagicMock, call
+
+from typer import echo as typer_echo
 from typer.testing import CliRunner
 
 from scaffoldr.exceptions import TemplateError
 from scaffoldr.main import app
 
 runner = CliRunner()
+
+
+def test_init_command_dry_run(tmp_path, monkeypatch):
+    mock_dry_run_scaffold = MagicMock()
+    monkeypatch.setattr(
+        "scaffoldr.init.dry_run_scaffold",
+        mock_dry_run_scaffold,
+    )
+
+    result = runner.invoke(
+        app,
+        ["init", "foo", "--path", f"{tmp_path}", "--dry-run"],
+    )
+
+    assert result.exit_code == 0
+    assert mock_dry_run_scaffold.call_args_list[0] == call(
+        "foo", "default", tmp_path, typer_echo
+    )
 
 
 def test_init_command_scaffold_raises_template_error(

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from scaffoldr.exceptions import LocalError
-from scaffoldr.local import scaffold
+from scaffoldr.local import dry_run_scaffold, scaffold
 from scaffoldr.user_config import Config
 
 DUMMY_CONFIG = Config(
@@ -57,7 +57,6 @@ def test_git_repo_initialized(project):
 
 
 def test_already_exists_raises(tmp_path):
-
     with patch(
         "scaffoldr.local.Config.load", return_value=DUMMY_CONFIG
     ):
@@ -84,3 +83,64 @@ def test_ci_workflow_contains_explicit_installs(project):
         project / ".github" / "workflows" / "ci.yml"
     ).read_text()
     assert "pip install ruff pytest" in content
+
+
+def test_dry_run_scaffold_already_exists(
+    tmp_path, monkeypatch, make_mock_config
+):
+    _ = make_mock_config("scaffoldr.utils.Config.load")
+
+    path = tmp_path / "project"
+    path.mkdir(parents=True, exist_ok=True)
+
+    progress = []
+
+    with pytest.raises(
+        LocalError, match=f"Error: {path} already exists."
+    ):
+        dry_run_scaffold(
+            "project", "template", tmp_path, progress.append
+        )
+
+    assert len(progress) == 0
+
+
+def test_dry_run_scaffold_happy_path(
+    tmp_path, monkeypatch, make_mock_config
+):
+    _ = make_mock_config("scaffoldr.utils.Config.load")
+
+    template_path = tmp_path / "template.toml"
+    template_path.write_text("""
+description = "default scaffolding for python project"
+
+[[files]]
+path = "README.md"
+content = ""
+
+[[files]]
+path = "CONTRIBUTING.md"
+content = ""
+""")
+
+    monkeypatch.setattr(
+        "scaffoldr.local.resolve_template_path",
+        lambda *a: template_path,
+    )
+
+    progress = []
+
+    dry_run_scaffold(
+        "project", "template", tmp_path, progress.append
+    )
+
+    assert [
+        "[dry-run] Would create: "
+        f"{(tmp_path / 'project' / 'README.md')}",
+        "[dry-run] Would create: "
+        f"{(tmp_path / 'project' / 'CONTRIBUTING.md')}",
+        f"[dry-run] @{(tmp_path / 'project')}: git init",
+        f"[dry-run] @{(tmp_path / 'project')}: git add .",
+        f"[dry-run] @{(tmp_path / 'project')}: "
+        'git commit -m "chore: initial scaffold"',
+    ] == progress

--- a/tests/test_new.py
+++ b/tests/test_new.py
@@ -10,21 +10,6 @@ runner = CliRunner()
 
 
 @pytest_fixture
-def mock_config(monkeypatch):
-    config = MagicMock()
-    config.default_private = True
-    config.use_ssh = True
-    config.github_username = "user"
-    config.required_reviewers = 1
-    config.github_token = "token"
-
-    monkeypatch.setattr(
-        "scaffoldr.new.Config.load", lambda: config
-    )
-    return config
-
-
-@pytest_fixture
 def mock_git_cmd_runner(monkeypatch):
     git_cmd_runner = MagicMock()
 
@@ -72,12 +57,12 @@ def mock_github_deps(monkeypatch):
 def test_new_use_ssh(
     tmp_path,
     monkeypatch,
-    mock_config,
+    make_mock_config,
     mock_git_cmd_runner,
     mock_github_deps,
 ):
     mock_repo = mock_github_deps
-
+    _ = make_mock_config("scaffoldr.new.Config.load")
     result = runner.invoke(
         app,
         [
@@ -100,11 +85,12 @@ def test_new_use_ssh(
 def test_new_do_not_use_ssh(
     tmp_path,
     monkeypatch,
-    mock_config,
+    make_mock_config,
     mock_git_cmd_runner,
     mock_github_deps,
 ):
     mock_repo = mock_github_deps
+    mock_config = make_mock_config("scaffoldr.new.Config.load")
     mock_config.use_ssh = False
 
     result = runner.invoke(
@@ -149,12 +135,12 @@ def test_new_do_not_use_ssh(
 def test_new_do_not_protect_branch(
     tmp_path,
     monkeypatch,
-    mock_config,
+    make_mock_config,
     mock_git_cmd_runner,
     mock_github_deps,
 ):
     mock_repo = mock_github_deps
-
+    _ = make_mock_config("scaffoldr.new.Config.load")
     result = runner.invoke(
         app,
         [
@@ -179,10 +165,11 @@ def test_new_do_not_protect_branch(
 def test_new_raises_exception(
     tmp_path,
     monkeypatch,
-    mock_config,
+    make_mock_config,
     mock_git_cmd_runner,
     mock_github_deps,
 ):
+    _ = make_mock_config("scaffoldr.new.Config.load")
     monkeypatch.setattr(
         "scaffoldr.new._scaffold",
         lambda *a: (_ for _ in ()).throw(

--- a/tests/test_new.py
+++ b/tests/test_new.py
@@ -1,8 +1,8 @@
 from unittest.mock import MagicMock, call
 
 from pytest import fixture as pytest_fixture
-from typer.testing import CliRunner
 from typer import echo as typer_echo
+from typer.testing import CliRunner
 
 from scaffoldr.exceptions import TemplateError
 from scaffoldr.main import app

--- a/tests/test_new.py
+++ b/tests/test_new.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock, call
 
 from pytest import fixture as pytest_fixture
 from typer.testing import CliRunner
+from typer import echo as typer_echo
 
 from scaffoldr.exceptions import TemplateError
 from scaffoldr.main import app
@@ -191,3 +192,40 @@ def test_new_raises_exception(
 
     assert result.exit_code == 1
     assert result.output == "simulated.\n"
+
+
+def test_new_dry_run(tmp_path, monkeypatch, make_mock_config):
+    _ = make_mock_config("scaffoldr.new.Config.load")
+
+    mock_dry_run_scaffold = MagicMock()
+    monkeypatch.setattr(
+        "scaffoldr.new.dry_run_scaffold", mock_dry_run_scaffold
+    )
+
+    mock_dry_run_github_ops = MagicMock()
+    monkeypatch.setattr(
+        "scaffoldr.new.dry_run_github_ops",
+        mock_dry_run_github_ops,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "new",
+            "foo",
+            "--description",
+            "bar",
+            "--path",
+            f"{tmp_path}",
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert mock_dry_run_scaffold.call_args_list[0] == call(
+        "foo", "default", tmp_path, typer_echo
+    )
+
+    assert mock_dry_run_github_ops.call_args_list[0] == call(
+        "foo", True, True, typer_echo
+    )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,10 +3,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 from typer import Abort as typer_abort
 
-from scaffoldr.exceptions import GitError
+from scaffoldr.exceptions import GitError, LocalError
 from scaffoldr.utils import (
     _git,
     check_legacy_config,
+    dry_run_scaffold,
     ensure_dirs,
 )
 
@@ -60,3 +61,64 @@ def test_legacy_path_exists(tmp_path):
     ):
         with pytest.raises(typer_abort):
             check_legacy_config()
+
+
+def test_dry_run_scaffold_already_exists(
+    tmp_path, monkeypatch, make_mock_config
+):
+    _ = make_mock_config("scaffoldr.utils.Config.load")
+
+    path = tmp_path / "project"
+    path.mkdir(parents=True, exist_ok=True)
+
+    progress = []
+
+    with pytest.raises(
+        LocalError, match=f"Error: {path} already exists."
+    ):
+        dry_run_scaffold(
+            "project", "template", tmp_path, progress.append
+        )
+
+    assert len(progress) == 0
+
+
+def test_dry_run_scaffold_happy_path(
+    tmp_path, monkeypatch, make_mock_config
+):
+    _ = make_mock_config("scaffoldr.utils.Config.load")
+
+    template_path = tmp_path / "template.toml"
+    template_path.write_text("""
+description = "default scaffolding for python project"
+
+[[files]]
+path = "README.md"
+content = ""
+
+[[files]]
+path = "CONTRIBUTING.md"
+content = ""
+""")
+
+    monkeypatch.setattr(
+        "scaffoldr.utils.resolve_template_path",
+        lambda *a: template_path,
+    )
+
+    progress = []
+
+    dry_run_scaffold(
+        "project", "template", tmp_path, progress.append
+    )
+
+    assert [
+        "[dry-run] Would create: "
+        f"{(tmp_path / 'project' / 'README.md')}",
+        "[dry-run] Would create: "
+        f"{(tmp_path / 'project' / 'CONTRIBUTING.md')}",
+        f"[dry-run] @{(tmp_path / 'project')}: git init",
+        f"[dry-run] @{(tmp_path / 'project')}: git add .",
+        f"[dry-run] @{(tmp_path / 'project')}: "
+        'git commit -m "chore: initial scaffold"',
+    ] == progress

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,11 +3,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 from typer import Abort as typer_abort
 
-from scaffoldr.exceptions import GitError, LocalError
+from scaffoldr.exceptions import GitError
 from scaffoldr.utils import (
     _git,
     check_legacy_config,
-    dry_run_scaffold,
     ensure_dirs,
 )
 
@@ -61,64 +60,3 @@ def test_legacy_path_exists(tmp_path):
     ):
         with pytest.raises(typer_abort):
             check_legacy_config()
-
-
-def test_dry_run_scaffold_already_exists(
-    tmp_path, monkeypatch, make_mock_config
-):
-    _ = make_mock_config("scaffoldr.utils.Config.load")
-
-    path = tmp_path / "project"
-    path.mkdir(parents=True, exist_ok=True)
-
-    progress = []
-
-    with pytest.raises(
-        LocalError, match=f"Error: {path} already exists."
-    ):
-        dry_run_scaffold(
-            "project", "template", tmp_path, progress.append
-        )
-
-    assert len(progress) == 0
-
-
-def test_dry_run_scaffold_happy_path(
-    tmp_path, monkeypatch, make_mock_config
-):
-    _ = make_mock_config("scaffoldr.utils.Config.load")
-
-    template_path = tmp_path / "template.toml"
-    template_path.write_text("""
-description = "default scaffolding for python project"
-
-[[files]]
-path = "README.md"
-content = ""
-
-[[files]]
-path = "CONTRIBUTING.md"
-content = ""
-""")
-
-    monkeypatch.setattr(
-        "scaffoldr.utils.resolve_template_path",
-        lambda *a: template_path,
-    )
-
-    progress = []
-
-    dry_run_scaffold(
-        "project", "template", tmp_path, progress.append
-    )
-
-    assert [
-        "[dry-run] Would create: "
-        f"{(tmp_path / 'project' / 'README.md')}",
-        "[dry-run] Would create: "
-        f"{(tmp_path / 'project' / 'CONTRIBUTING.md')}",
-        f"[dry-run] @{(tmp_path / 'project')}: git init",
-        f"[dry-run] @{(tmp_path / 'project')}: git add .",
-        f"[dry-run] @{(tmp_path / 'project')}: "
-        'git commit -m "chore: initial scaffold"',
-    ] == progress


### PR DESCRIPTION
## What

Added --dry-run flag that prints what would happen without
writing files or calling GitHub API.

## Changes
- `scaffoldr/github.py`: added `dry_run_github_ops` helper fn
- `scaffoldr/init.py`: added `--dry-run` flag to init command
- `tests/test_new.py`: refactored to use `make_mock_config`; added
  test for `new` command with `--dry-run` flag
- `tests/test_init.py`: added test for `init` command with 
  `--dry-run` flag
- `scaffoldr/utils.py`: added `build_scaffold_variables`
- `tests/test_github.py`: added test for `dry_run_github_ops`
- `tests/config/test_show.py`: refactored to use `make_mock_config`
  (side effect of shared fixture refactor)
- `tests/conftest.py`: added `make_mock_config` pytest fixture
- `scaffoldr/new.py`: added `--dry-run` flag to new command
- `scaffoldr/local.py`: refactored `scaffold` to use 
  `build_scaffold_variables`; moved `dry_run_scaffold` helper from
  `scaffoldr/utils.py`
- `tests/test_local.py`: added tests for `dry_run_scaffold`

## Why
Allows users to preview/understand what would happen on running
`scaffoldr` with the options they have set.

## Impact
No breaking changes. 

## Checklist
- [x] All tests pass
- [x] CI green
- [x] Closes #35 